### PR TITLE
remove unused dependency for openssl

### DIFF
--- a/packaging/build_deb
+++ b/packaging/build_deb
@@ -41,7 +41,7 @@ cat << 'EOF' >> debian/control
 
 Package: libnginx-mod-http-sxg-filter
 Architecture: any
-Depends: libssl-dev (>= 1.1.1c), ${misc:Depends}, ${shlibs:Depends}
+Depends: ${misc:Depends}, ${shlibs:Depends}
 Description: Signed HTTP Exchange filter module for nginx.
  An nginx module that generates SXG response from upstream when clients request
  it.


### PR DESCRIPTION
nginx-sxg module itself does not depend on `libssl-dev` directly.
libsxg depends on nginx-sxg, so nginx-sxg module is indirectly depends on `libssl-dev` it should not specified in the `Depends` list.