### PR TITLE
prioritize sxg

### DIFF
--- a/ngx_sxg_utils.c
+++ b/ngx_sxg_utils.c
@@ -167,7 +167,7 @@ bool highest_qvalue_is_sxg(const char* str, size_t len) {
     const size_t tail = get_term_length(str, len, ',', "<>");
     const bool is_sxg = term_is_sxg(str, tail);
     const int p = get_priority(str, tail);
-    if (max_priority < p) {
+    if (max_priority < p || (max_priority == p && is_sxg)) {
       should_be_sxg = is_sxg;
       max_priority = p;
     }

--- a/ngx_sxg_utils_test.cc
+++ b/ngx_sxg_utils_test.cc
@@ -51,6 +51,8 @@ TEST(NgxSxgUtilsTest, ShouldBeSignedExchange) {
       "application/signed-exchange;v=b3;q=1.000   ,text/html;q=0.999"));
   EXPECT_TRUE(ShouldBeSXG(
       "application/signed-exchange;q=0.999; v=b3 ,text/html; q=0.998 "));
+  EXPECT_TRUE(ShouldBeSXG("application/signed-exchange;v=b3,text/html"));
+  EXPECT_TRUE(ShouldBeSXG("*/*,text/html,application/signed-exchange;v=b3"));
   EXPECT_FALSE(ShouldBeSXG("v=b3"));
   EXPECT_FALSE(
       ShouldBeSXG("application/signed-exchange;q=0.9999;v=b3,text/html;q=0.5"));


### PR DESCRIPTION
If `Accept` header has the same qvalue for multiple types like `Accept: text/html, application/signed-exchange;v=b3`, the return type is depends on server's matter.
In such case, the webmaster would like to send SXG files as long as using this plugin and enables feature, I believe.