### PR TITLE
add vary and nosniff header in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,6 +82,8 @@ http {
     server {
         listen    80;
         server_name  example.com;
+        add_header X-Content-Type-Options nosniff;
+        add_header Vary Accept;
 
         sxg on;
         sxg_certificate     /path/to/certificate-ecdsa.pem;


### PR DESCRIPTION
https://github.com/google/nginx-sxg-module/issues/3
https://github.com/google/nginx-sxg-module/issues/4
Nginx can resolve these issues by its default functionality.
nginx-sxg-module should resolve it for safety, but by the time of implemented, add documentation would be good first-aid.