### PR TITLE
drop support of disco, append support focal

### DIFF
--- a/.github/workflows/release-action.yml
+++ b/.github/workflows/release-action.yml
@@ -9,10 +9,10 @@ jobs:
         names:
           - base_image: "ubuntu:bionic"
             image_name: "bionic"
-          - base_image: "ubuntu:disco"
-            image_name: "disco"
           - base_image: "ubuntu:eoan"
             image_name: "eoan"
+          - base_image: "ubuntu:focal"
+            image_name: "focal"
           - base_image: "debian:buster"
             image_name: "buster"
     steps:


### PR DESCRIPTION
Support of Ubuntu 19.04(Disco Dingo) is terminated in [January 2020](https://wiki.ubuntu.com/DiscoDingo/ReleaseNotes)
And Ubuntu 20.04 LTS (Focal Fossa) is newly [released](https://wiki.ubuntu.com/FocalFossa/ReleaseNotes).