### PR TITLE
update make-debs.yaml to drop support of disco

### DIFF
--- a/.github/workflows/make-debs.yml
+++ b/.github/workflows/make-debs.yml
@@ -9,10 +9,10 @@ jobs:
         names:
           - base_image: "ubuntu:bionic"
             image_name: "bionic"
-          - base_image: "ubuntu:disco"
-            image_name: "disco"
           - base_image: "ubuntu:eoan"
             image_name: "eoan"
+          - base_image: "ubuntu:focal"
+            image_name: "focal"
           - base_image: "debian:buster"
             image_name: "buster"
     steps:


### PR DESCRIPTION
Forgot to update another file to check build-ability for multiple Ubuntu versions.