### PR TITLE
non-interactive mode is required to skip infinity wait in apt-get

### DIFF
--- a/packaging/deb.dockerfile
+++ b/packaging/deb.dockerfile
@@ -3,6 +3,8 @@ FROM ${base_image}
 
 LABEL maintainer "Hiroki Kumazaki <kumagi@google.com>"
 
+ENV DEBIAN_FRONTEND=noninteractive
+
 RUN apt-get update && \
     apt-get install -y --no-install-recommends -q \
                     build-essential \


### PR DESCRIPTION
without this fix, building package is to be failed with timeout like [this](https://github.com/google/nginx-sxg-module/runs/635987798?check_suite_focus=true)