### PR TITLE
add selfcheck workflow with Docker

### DIFF
--- a/.github/workflows/end-to-end-test.yml
+++ b/.github/workflows/end-to-end-test.yml
@@ -1,0 +1,49 @@
+name: 'End-to-end test with docker'
+on: push
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        names:
+          - base_image: "ubuntu:bionic"
+            image_name: "bionic"
+          - base_image: "ubuntu:eoan"
+            image_name: "eoan"
+          - base_image: "ubuntu:focal"
+            image_name: "focal"
+          - base_image: "debian:buster"
+            image_name: "buster"
+    steps:
+      - uses: actions/checkout@v1
+
+      - name: Prepare deb file
+        run: |
+          docker build --build-arg base_image=${{ matrix.names.base_image }} -t ${{ matrix.names.image_name }} -f packaging/deb.dockerfile .
+          docker run --rm --mount "type=bind,source=$(pwd)/test,target=/nginx-sxg-module/output" ${{ matrix.names.image_name }}
+
+      - name: Prepare key and self-signed certificate pair
+        run: |
+          pushd test
+          ./generate.sh
+          popd
+
+      - name: Do end-to-end test
+        run: |
+          pushd test
+          mkdir out
+          docker build --build-arg base_image=${{ matrix.names.base_image }} -t nginx .
+          docker run --mount type=bind,src=$(pwd)/out,dst=/data/result nginx
+          popd
+
+      - name: Extract results
+        run: |
+          cat test/out/error.log
+          cat test/out/index.sxg
+
+      - name: Upload artifacts
+        uses: actions/upload-artifact@v1
+        with:
+          name: nginx-sxg-${{ matrix.names.image_name }}
+          path: test/out

--- a/ngx_http_sxg_filter_module.c
+++ b/ngx_http_sxg_filter_module.c
@@ -694,6 +694,12 @@ static ngx_int_t ngx_http_sxg_filter_init(ngx_conf_t* cf) {
 
     EVP_PKEY* privkey =
         load_private_key((const char*)nscf->certificate_key.data);
+    if (privkey == NULL) {
+      ngx_log_error(NGX_LOG_NOTICE, cf->log, 0,
+                    "nginx-sxg-module: failed to load private key %V",
+                    &nscf->certificate_key);
+      return NGX_ERROR;
+    }
     X509* cert = load_x509_cert((const char*)nscf->certificate.data);
     if (!sxg_add_ecdsa_signer("nginx", /*date=*/0, /*expires=*/0,
                               (const char*)nscf->validity_url.data, privkey,

--- a/test/Dockerfile
+++ b/test/Dockerfile
@@ -1,0 +1,28 @@
+ARG base_image
+FROM ${base_image}
+
+WORKDIR /data
+RUN apt-get update && apt-get install -y nginx wget unzip curl && \
+    apt-get install -y libssl-dev && \
+    wget https://github.com/google/libsxg/releases/download/v0.2/libsxg0_0.2-1_amd64.deb && \
+    wget https://github.com/google/libsxg/releases/download/v0.2/libsxg-dev_0.2-1_amd64.deb && \
+    dpkg -i libsxg0_0.2-1_amd64.deb && \
+    dpkg -i libsxg-dev_0.2-1_amd64.deb
+
+COPY libnginx-mod-http-sxg-filter*.deb .
+RUN dpkg -i libnginx-mod-http-sxg-filter*.deb
+
+COPY ssl.crt .
+COPY ssl.key .
+COPY sxg.crt .
+COPY sxg.key .
+COPY nginx-sxg.conf /etc/nginx/sites-enabled/
+COPY index.html /var/www/nginx-sxg.test/
+RUN mkdir result
+RUN chmod 755 -R /var/www/nginx-sxg.test/
+
+COPY selfcheck.sh .
+
+EXPOSE 443
+
+ENTRYPOINT ["./selfcheck.sh"]

--- a/test/generate.sh
+++ b/test/generate.sh
@@ -1,0 +1,15 @@
+#!/bin/bash -ex
+
+# generate ssl key and self signed certificate
+openssl req -nodes -newkey rsa:2048 -keyout ssl.key -out ssl.csr -subj "/C=US/O=Test/CN=nginx-sxg.test"
+openssl x509 -req -days 365 -signkey ssl.key < ssl.csr > ssl.crt
+rm ssl.csr
+
+# generate sxg key and self signed certificate
+openssl ecparam -out sxg.key -name prime256v1 -genkey
+openssl req -new -sha256 -key sxg.key -out sxg.csr -subj '/C=US/O=Test/CN=nginx-sxg.test'
+
+openssl x509 -req -days 90 -in sxg.csr -signkey sxg.key -out sxg.crt \
+  -extfile <(echo -e "1.3.6.1.4.1.11129.2.1.22 = ASN1:NULL\nsubjectAltName=DNS:nginx-sxg.test")
+rm sxg.csr
+

--- a/test/index.html
+++ b/test/index.html
@@ -1,0 +1,8 @@
+<html>
+  <body>
+    <h3>
+      This is a test page of nginx-sxg
+    </h3>
+    Is this page signed with SXG?
+  </body>
+</html>

--- a/test/nginx-sxg.conf
+++ b/test/nginx-sxg.conf
@@ -1,0 +1,23 @@
+add_header  X-Content-Type-Options nosniff;
+
+server {
+       listen 443 ssl;
+       ssl_certificate     /data/ssl.crt;
+       ssl_certificate_key /data/ssl.key;
+       server_name         nginx-sxg.test;
+       error_log           /var/log/nginx/error.log debug;
+       rewrite_log         on;
+
+       sxg on;
+       sxg_certificate     /data/sxg.crt;
+       sxg_certificate_key /data/sxg.key;
+       sxg_cert_url        https://nginx-sxg.test/certs/cert.cbor;
+       sxg_validity_url    https://nginx-sxg.test/validity/resource.msg;
+
+       # nginx-sxg-module cannot resolve OCSP stapling because this is self-signed certificate.
+       # So, do not enable this line.
+       # sxg_cert_path       /cert.cbor;  
+
+       root /var/www/nginx-sxg.test;
+       index index.html;
+}

--- a/test/selfcheck.sh
+++ b/test/selfcheck.sh
@@ -1,0 +1,16 @@
+#!/bin/bash -ex
+
+cat /etc/nginx/sites-enabled/default
+cat /etc/nginx/sites-enabled/nginx-sxg.conf
+rm /etc/nginx/sites-enabled/default
+service nginx restart
+
+rm -rf out
+mkdir out
+curl -H"Host:nginx-sxg.test" -H"Accept:application/signed-exchange;v=b3" https://127.0.0.1/ -k --output - > /data/result/index.sxg
+cp /var/log/nginx/error.log /data/result/
+chmod -R 755 /data/result
+
+cat result/index.sxg
+cat result/error.log
+#cat /etc/nginx/nginx.conf


### PR DESCRIPTION
Stand alone testing using Docker is beneficial for check validity and can be useful for users to setup the module for their own container environment.