### PR TITLE
error message should be appeared with NGX_LOG_EMERG

### DIFF
--- a/ngx_http_sxg_filter_module.c
+++ b/ngx_http_sxg_filter_module.c
@@ -696,14 +696,14 @@ static ngx_int_t ngx_http_sxg_filter_init(ngx_conf_t* cf) {
         load_private_key((const char*)nscf->certificate_key.data);
     if (privkey == NULL) {
       ngx_log_error(NGX_LOG_EMERG, cf->log, 0,
-                    "nginx-sxg-module: failed to load private key %V",
+                    "nginx-sxg-module: failed to load private key at %V",
                     &nscf->certificate_key);
       return NGX_ERROR;
     }
     X509* cert = load_x509_cert((const char*)nscf->certificate.data);
     if (cert == NULL) {
       ngx_log_error(NGX_LOG_EMERG, cf->log, 0,
-                    "nginx-sxg-module: failed to load certificate %V",
+                    "nginx-sxg-module: failed to load certificate at %V",
                     &nscf->certificate);
       return NGX_ERROR;
     }
@@ -713,7 +713,7 @@ static ngx_int_t ngx_http_sxg_filter_init(ngx_conf_t* cf) {
                               cert, (const char*)nscf->cert_url.data,
                               &nscf->signers)) {
       ngx_log_error(NGX_LOG_EMERG, cf->log, 0,
-                    "nginx-sxg-module: failed to load certificates");
+                    "nginx-sxg-module: failed to allocate memory");
 
       return NGX_ERROR;
     }

--- a/ngx_http_sxg_filter_module.c
+++ b/ngx_http_sxg_filter_module.c
@@ -687,7 +687,7 @@ static ngx_int_t ngx_http_sxg_filter_init(ngx_conf_t* cf) {
     }
 
     if (!is_valid_config(cf, nscf)) {
-      ngx_log_error(NGX_LOG_ERR, cf->log, 0,
+      ngx_log_error(NGX_LOG_EMERG, cf->log, 0,
                     "nginx-sxg-module: invalid config");
       return NGX_ERROR;
     }
@@ -695,14 +695,14 @@ static ngx_int_t ngx_http_sxg_filter_init(ngx_conf_t* cf) {
     EVP_PKEY* privkey =
         load_private_key((const char*)nscf->certificate_key.data);
     if (privkey == NULL) {
-      ngx_log_error(NGX_LOG_ERR, cf->log, 0,
+      ngx_log_error(NGX_LOG_EMERG, cf->log, 0,
                     "nginx-sxg-module: failed to load private key %V",
                     &nscf->certificate_key);
       return NGX_ERROR;
     }
     X509* cert = load_x509_cert((const char*)nscf->certificate.data);
     if (cert == NULL) {
-      ngx_log_error(NGX_LOG_ERR, cf->log, 0,
+      ngx_log_error(NGX_LOG_EMERG, cf->log, 0,
                     "nginx-sxg-module: failed to load certificate %V",
                     &nscf->certificate);
       return NGX_ERROR;
@@ -712,7 +712,7 @@ static ngx_int_t ngx_http_sxg_filter_init(ngx_conf_t* cf) {
                               (const char*)nscf->validity_url.data, privkey,
                               cert, (const char*)nscf->cert_url.data,
                               &nscf->signers)) {
-      ngx_log_error(NGX_LOG_ERR, cf->log, 0,
+      ngx_log_error(NGX_LOG_EMERG, cf->log, 0,
                     "nginx-sxg-module: failed to load certificates");
 
       return NGX_ERROR;

--- a/ngx_http_sxg_filter_module.c
+++ b/ngx_http_sxg_filter_module.c
@@ -687,7 +687,7 @@ static ngx_int_t ngx_http_sxg_filter_init(ngx_conf_t* cf) {
     }
 
     if (!is_valid_config(cf, nscf)) {
-      ngx_log_error(NGX_LOG_NOTICE, cf->log, 0,
+      ngx_log_error(NGX_LOG_ERR, cf->log, 0,
                     "nginx-sxg-module: invalid config");
       return NGX_ERROR;
     }
@@ -695,17 +695,24 @@ static ngx_int_t ngx_http_sxg_filter_init(ngx_conf_t* cf) {
     EVP_PKEY* privkey =
         load_private_key((const char*)nscf->certificate_key.data);
     if (privkey == NULL) {
-      ngx_log_error(NGX_LOG_NOTICE, cf->log, 0,
+      ngx_log_error(NGX_LOG_ERR, cf->log, 0,
                     "nginx-sxg-module: failed to load private key %V",
                     &nscf->certificate_key);
       return NGX_ERROR;
     }
     X509* cert = load_x509_cert((const char*)nscf->certificate.data);
+    if (cert == NULL) {
+      ngx_log_error(NGX_LOG_ERR, cf->log, 0,
+                    "nginx-sxg-module: failed to load certificate %V",
+                    &nscf->certificate);
+      return NGX_ERROR;
+    }
+
     if (!sxg_add_ecdsa_signer("nginx", /*date=*/0, /*expires=*/0,
                               (const char*)nscf->validity_url.data, privkey,
                               cert, (const char*)nscf->cert_url.data,
                               &nscf->signers)) {
-      ngx_log_error(NGX_LOG_NOTICE, cf->log, 0,
+      ngx_log_error(NGX_LOG_ERR, cf->log, 0,
                     "nginx-sxg-module: failed to load certificates");
 
       return NGX_ERROR;

--- a/test/selfcheck.sh
+++ b/test/selfcheck.sh
@@ -3,7 +3,7 @@
 cat /etc/nginx/sites-enabled/default
 cat /etc/nginx/sites-enabled/nginx-sxg.conf
 rm /etc/nginx/sites-enabled/default
-service nginx restart
+service nginx restart || cat /var/log/nginx/error.log
 
 rm -rf out
 mkdir out

--- a/test/selfcheck.sh
+++ b/test/selfcheck.sh
@@ -3,7 +3,11 @@
 cat /etc/nginx/sites-enabled/default
 cat /etc/nginx/sites-enabled/nginx-sxg.conf
 rm /etc/nginx/sites-enabled/default
-service nginx restart || cat /var/log/nginx/error.log
+
+if ! service nginx restart; then
+  cat /var/log/nginx/error.log
+  return 1
+fi
 
 rm -rf out
 mkdir out


### PR DESCRIPTION
Fatal error should use NGX_LOG_EMERG like [failed to load a SSL certificates](https://github.com/nginx/nginx/blob/master/src/event/ngx_event_openssl.c#L1327-L1332).