### PR TITLE
Don't embed subresource preload header when nginx failed to fetch

### DIFF
--- a/ngx_http_sxg_filter_module.c
+++ b/ngx_http_sxg_filter_module.c
@@ -336,8 +336,8 @@ static ngx_str_t extract_angled_url(char* str, size_t len) {
 // TODO(kumagi): Complex logic should be migrated to ngx_sxg_utils.c.
 // Extracts URL list `dst` from `link` like </foo.js>;rel="preload";as="script"
 // Returns length of non-preload header string.
-// If `dst` is NULL, it just calculate the length of estimatec
-// non_preload_headers.
+// If `dst` is NULL, it does nothing than calculates and returns the required
+// length for `non_preload_headers`.
 static size_t extract_preload_url_list(ngx_str_t* link, ngx_array_t* const dst,
                                        ngx_str_t* non_preload_headers,
                                        ngx_http_request_t* r) {
@@ -363,7 +363,7 @@ static size_t extract_preload_url_list(ngx_str_t* link, ngx_array_t* const dst,
           new_preload->url.len = url.len;
           ngx_memcpy(new_preload->url.data, url.data, url.len);
           while (new_preload->url.data[new_preload->url.len - 1] == ' ') {
-            new_preload->url.len--;
+            new_preload->url.data[--new_preload->url.len] = '\0';
           }
           if (as.data != NULL) {
             new_preload->as = as;

--- a/ngx_http_sxg_filter_module.c
+++ b/ngx_http_sxg_filter_module.c
@@ -842,7 +842,6 @@ static ngx_int_t ngx_http_sxg_filter_init(ngx_conf_t* cf) {
                               &nscf->signers)) {
       ngx_log_error(NGX_LOG_EMERG, cf->log, 0,
                     "nginx-sxg-module: failed to allocate memory");
-
       return NGX_ERROR;
     }
     if (nscf->cert_path.len > 0 &&

--- a/ngx_sxg_utils.c
+++ b/ngx_sxg_utils.c
@@ -216,6 +216,31 @@ bool param_is_preload(const char* param, size_t len) {
   }
 }
 
+bool param_is_as(const char* param, size_t len, const char** value,
+                 size_t* value_len) {
+  static const char kRel[] = "as=";
+  *value = NULL;
+  *value_len = 0;
+  if (len < sizeof(kRel) - 1 ||
+      strncmp((char*)param, kRel, sizeof(kRel) - 1) != 0) {
+    return false;
+  }
+  param += sizeof(kRel) - 1;
+  len -= sizeof(kRel) - 1;
+  if (len > 0 && *param == '"') {
+    const char* end = strchr(param + 1, '"');
+    if (end == NULL) {
+      return false;
+    }
+    *value = param + 1;
+    *value_len = end - param - 1;
+  } else {
+    *value = param;
+    *value_len = len;
+  }
+  return true;
+}
+
 EVP_PKEY* load_private_key(const char* filepath) {
   FILE* const fp = fopen(filepath, "r");
   if (!fp) {

--- a/ngx_sxg_utils.h
+++ b/ngx_sxg_utils.h
@@ -54,6 +54,11 @@ bool highest_qvalue_is_sxg(const char* param, size_t len);
 // e.g. rel="foo preload bar" -> true
 bool param_is_preload(const char* param, size_t len);
 
+// Detects as="*" parameter in HTTP link header.
+// e.g. as="image" -> true
+bool param_is_as(const char* param, size_t len, const char** value,
+                 size_t* value_len);
+
 // Loads and create EVP_PKEY struct from private key filepath.
 EVP_PKEY* load_private_key(const char* filepath);
 

--- a/ngx_sxg_utils_test.cc
+++ b/ngx_sxg_utils_test.cc
@@ -75,6 +75,11 @@ bool ParamIsPreload(const std::string& input) {
 
 TEST(NgxSxgUtilsTest, ParamIsPreload) {
   EXPECT_TRUE(ParamIsPreload("rel=preload"));
+  EXPECT_TRUE(ParamIsPreload(" rel=preload"));
+  EXPECT_TRUE(ParamIsPreload("rel=preload "));
+  EXPECT_TRUE(ParamIsPreload("rel= preload"));
+  EXPECT_TRUE(ParamIsPreload("rel=\" preload\""));
+  EXPECT_TRUE(ParamIsPreload("rel=\"preload \""));
   EXPECT_TRUE(ParamIsPreload(R"(rel="preload")"));
   EXPECT_TRUE(ParamIsPreload(R"(rel="alter preload hello world")"));
   EXPECT_FALSE(ParamIsPreload("preload=rel"));
@@ -86,6 +91,9 @@ TEST(NgxSxgUtilsTest, ParamIsPreload) {
   EXPECT_FALSE(ParamIsPreload("rel=\"\n \""));
   EXPECT_FALSE(ParamIsPreload("r"));
   EXPECT_FALSE(ParamIsPreload("rel=prepreload"));
+
+  // TODO: we should support this pattern.
+  // EXPECT_TRUE(ParamIsPreload("rel= preload"));
 }
 
 TEST(NgxSxgCertChain, free) {

--- a/ngx_sxg_utils_test.cc
+++ b/ngx_sxg_utils_test.cc
@@ -93,7 +93,7 @@ TEST(NgxSxgUtilsTest, ParamIsPreload) {
   EXPECT_FALSE(ParamIsPreload("rel=prepreload"));
 
   // TODO: we should support this pattern.
-  // EXPECT_TRUE(ParamIsPreload("rel= preload"));
+  // EXPECT_TRUE(ParamIsPreload("rel =preload"));
 }
 
 TEST(NgxSxgCertChain, free) {


### PR DESCRIPTION
fix #35 
All `link: rel="preload">` subresource should include `allowed-alt-sxg` entry with integrity to preserve privacy.

TODO: add some test.