### PR TITLE
add nosniff outer header automatically

### DIFF
--- a/.github/workflows/end-to-end-test.yml
+++ b/.github/workflows/end-to-end-test.yml
@@ -35,10 +35,9 @@ jobs:
           mkdir out
           docker build --build-arg base_image=${{ matrix.names.base_image }} -t nginx .
           docker run --mount type=bind,src=$(pwd)/out,dst=/data/result nginx
-          echo "hello, now try to test"
-          test $(md5sum out/index.sxg | cut -d' ' -f 1) != "633a359d9e12522fe26a671927b989e8"
-          test $(md5sum out/index.html | cut -d' ' -f 1) = "633a359d9e12522fe26a671927b989e8"
-          test $(md5sum out/http.html | cut -d' ' -f 1) = "633a359d9e12522fe26a671927b989e8"
+          ! echo "633a359d9e12522fe26a671927b989e8  out/index.sxg" | md5sum -c -
+          echo "633a359d9e12522fe26a671927b989e8  out/index.html" | md5sum -c -
+          echo "633a359d9e12522fe26a671927b989e8  out/http.html" | md5sum -c -
           popd
 
       - name: Extract results

--- a/.github/workflows/end-to-end-test.yml
+++ b/.github/workflows/end-to-end-test.yml
@@ -36,9 +36,9 @@ jobs:
           docker build --build-arg base_image=${{ matrix.names.base_image }} -t nginx .
           docker run --mount type=bind,src=$(pwd)/out,dst=/data/result nginx
           echo "hello, now try to test"
-          test $(md5sum out/index.sxg | awk '{print $1}') != "633a359d9e12522fe26a671927b989e8"
-          test $(md5sum out/index.html | awk '{print $1}') = "633a359d9e12522fe26a671927b989e8"
-          test $(md5sum out/http.html | awk '{print $1}') = "633a359d9e12522fe26a671927b989e8"
+          test $(md5sum out/index.sxg | cut -d' ' -f 1) != "633a359d9e12522fe26a671927b989e8"
+          test $(md5sum out/index.html | cut -d' ' -f 1) = "633a359d9e12522fe26a671927b989e8"
+          test $(md5sum out/http.html | cut -d' ' -f 1) = "633a359d9e12522fe26a671927b989e8"
           popd
 
       - name: Extract results

--- a/.github/workflows/end-to-end-test.yml
+++ b/.github/workflows/end-to-end-test.yml
@@ -35,6 +35,7 @@ jobs:
           mkdir out
           docker build --build-arg base_image=${{ matrix.names.base_image }} -t nginx .
           docker run --mount type=bind,src=$(pwd)/out,dst=/data/result nginx
+          echo "hello, now try to test"
           test $(md5sum out/index.sxg | awk '{print $1}') != "633a359d9e12522fe26a671927b989e8"
           test $(md5sum out/index.html | awk '{print $1}') == "633a359d9e12522fe26a671927b989e8"
           test $(md5sum out/http.html | awk '{print $1}') == "633a359d9e12522fe26a671927b989e8"

--- a/.github/workflows/end-to-end-test.yml
+++ b/.github/workflows/end-to-end-test.yml
@@ -45,6 +45,10 @@ jobs:
           cat test/out/error.log
           cat test/out/index.sxg
 
+      - name: check output
+        run: |
+          [[ "$(comm -2 test/out/index.headers expected.headers) == "" ]]
+
       - name: Upload artifacts
         uses: actions/upload-artifact@v1
         with:

--- a/.github/workflows/end-to-end-test.yml
+++ b/.github/workflows/end-to-end-test.yml
@@ -37,8 +37,8 @@ jobs:
           docker run --mount type=bind,src=$(pwd)/out,dst=/data/result nginx
           echo "hello, now try to test"
           test $(md5sum out/index.sxg | awk '{print $1}') != "633a359d9e12522fe26a671927b989e8"
-          test $(md5sum out/index.html | awk '{print $1}') == "633a359d9e12522fe26a671927b989e8"
-          test $(md5sum out/http.html | awk '{print $1}') == "633a359d9e12522fe26a671927b989e8"
+          test $(md5sum out/index.html | awk '{print $1}') = "633a359d9e12522fe26a671927b989e8"
+          test $(md5sum out/http.html | awk '{print $1}') = "633a359d9e12522fe26a671927b989e8"
           popd
 
       - name: Extract results

--- a/.github/workflows/end-to-end-test.yml
+++ b/.github/workflows/end-to-end-test.yml
@@ -45,9 +45,9 @@ jobs:
           cat test/out/error.log
           cat test/out/index.sxg
 
-      - name: check output
+      - name: check output header does not include etag
         run: |
-          [[ "$(comm -2 test/out/index.headers expected.headers) == "" ]]
+          if grep -qi "etag" test/out/index.header ; then exit 1; fi
 
       - name: Upload artifacts
         uses: actions/upload-artifact@v1

--- a/ngx_http_sxg_filter_module.c
+++ b/ngx_http_sxg_filter_module.c
@@ -831,13 +831,18 @@ static ngx_int_t ngx_http_sxg_body_filter_impl(ngx_http_request_t* req,
     return NGX_ERROR;
   }
 
-  ngx_table_elt_t* server = req->headers_out.server;
-  // Cleanup outer header.
+  // Cleanup outer headers and trailers.
   ngx_memzero(&req->headers_out, sizeof(ngx_http_headers_out_t));
   if (ngx_list_init(&req->headers_out.headers, req->pool, 1,
                     sizeof(ngx_table_elt_t)) != NGX_OK) {
     ngx_log_error(NGX_LOG_ERR, req->connection->log, 0,
                   "nginx-sxg-module: failed to initialize outer header list");
+    return NGX_ERROR;
+  }
+  if (ngx_list_init(&req->headers_out.trailers, req->pool, 1,
+                    sizeof(ngx_table_elt_t)) != NGX_OK) {
+    ngx_log_error(NGX_LOG_ERR, req->connection->log, 0,
+                  "nginx-sxg-module: failed to initialize trailers list");
     return NGX_ERROR;
   }
 

--- a/test/selfcheck.sh
+++ b/test/selfcheck.sh
@@ -7,11 +7,10 @@ fi
 
 rm -rf out
 mkdir out
-curl -i -H"Host:nginx-sxg.test" -H"Accept:application/signed-exchange;v=b3" https://127.0.0.1/bar/ -k --output - > /data/result/index.sxg
-curl -i -H"Host:nginx-sxg.test" -H"Accept:application/signed-exchange;v=b3" https://127.0.0.1/foo/ -k --output - > /data/result/index.html
-curl -i -H"Host:nginx-sxg.test" -H"Accept:application/signed-exchange;v=b3" https://127.0.0.1/bar/ -k --output - | egrep -m1 -B999 '^$'> /data/result/index.header
-curl -H"Host:nginx-no-sxg.test" -H"Accept:application/signed-exchange;v=b3" http://127.0.0.1:8080/ -k --output - > /data/result/http.html
-
+curl -sko- -H"Host:nginx-sxg.test" -H"Accept:application/signed-exchange;v=b3" https://127.0.0.1/bar/ -k --output - > /data/result/index.sxg
+curl -sko- -H"Host:nginx-sxg.test" -H"Accept:application/signed-exchange;v=b3" https://127.0.0.1/foo/ > /data/result/index.html
+curl -siko- -H"Host:nginx-sxg.test" -H"Accept:application/signed-exchange;v=b3" https://127.0.0.1/bar/ | tr -d '\r' | egrep -a -m1 -B999 '^$' > /data/result/index.header
+curl -siko- -H"Host:nginx-no-sxg.test" -H"Accept:application/signed-exchange;v=b3" http://127.0.0.1:8080/ > /data/result/http.html
 
 cp /var/log/nginx/error.log /data/result/
 chmod -R 755 /data/result
@@ -19,3 +18,4 @@ chmod -R 755 /data/result
 cat result/index.sxg
 cat result/error.log
 
+echo "####### selfcheck finished #######"

--- a/test/selfcheck.sh
+++ b/test/selfcheck.sh
@@ -10,7 +10,7 @@ mkdir out
 curl -sko- -H"Host:nginx-sxg.test" -H"Accept:application/signed-exchange;v=b3" https://127.0.0.1/bar/ -k --output - > /data/result/index.sxg
 curl -sko- -H"Host:nginx-sxg.test" -H"Accept:application/signed-exchange;v=b3" https://127.0.0.1/foo/ > /data/result/index.html
 curl -siko- -H"Host:nginx-sxg.test" -H"Accept:application/signed-exchange;v=b3" https://127.0.0.1/bar/ | tr -d '\r' | egrep -a -m1 -B999 '^$' > /data/result/index.header
-curl -siko- -H"Host:nginx-no-sxg.test" -H"Accept:application/signed-exchange;v=b3" http://127.0.0.1:8080/ > /data/result/http.html
+curl -sko- -H"Host:nginx-no-sxg.test" -H"Accept:application/signed-exchange;v=b3" http://127.0.0.1:8080/ > /data/result/http.html
 
 cp /var/log/nginx/error.log /data/result/
 chmod -R 755 /data/result

--- a/test/selfcheck.sh
+++ b/test/selfcheck.sh
@@ -1,9 +1,5 @@
 #!/bin/bash -ex
 
-cat /etc/nginx/sites-enabled/default
-cat /etc/nginx/sites-enabled/nginx-sxg.conf
-rm /etc/nginx/sites-enabled/default
-
 if ! service nginx restart; then
   cat /var/log/nginx/error.log
   return 1
@@ -11,12 +7,15 @@ fi
 
 rm -rf out
 mkdir out
-curl -H"Host:nginx-sxg.test" -H"Accept:application/signed-exchange;v=b3" https://127.0.0.1/bar/ -k --output - > /data/result/index.sxg
-curl -H"Host:nginx-sxg.test" -H"Accept:application/signed-exchange;v=b3" https://127.0.0.1/foo/ -k --output - > /data/result/index.html
+curl -i -H"Host:nginx-sxg.test" -H"Accept:application/signed-exchange;v=b3" https://127.0.0.1/bar/ -k --output - > /data/result/index.sxg
+curl -i -H"Host:nginx-sxg.test" -H"Accept:application/signed-exchange;v=b3" https://127.0.0.1/foo/ -k --output - > /data/result/index.html
+curl -i -H"Host:nginx-sxg.test" -H"Accept:application/signed-exchange;v=b3" https://127.0.0.1/bar/ -k --output - | egrep -m1 -B999 '^$'> /data/result/index.header
 curl -H"Host:nginx-no-sxg.test" -H"Accept:application/signed-exchange;v=b3" http://127.0.0.1:8080/ -k --output - > /data/result/http.html
+
+
 cp /var/log/nginx/error.log /data/result/
 chmod -R 755 /data/result
 
 cat result/index.sxg
 cat result/error.log
-#cat /etc/nginx/nginx.conf
+

--- a/test/selfcheck.sh
+++ b/test/selfcheck.sh
@@ -2,7 +2,7 @@
 
 if ! service nginx restart; then
   cat /var/log/nginx/error.log
-  return 1
+  exit 1
 fi
 
 rm -rf out

--- a/test/stand_alone_test.sh
+++ b/test/stand_alone_test.sh
@@ -1,0 +1,26 @@
+#!/bin/bash -ex
+
+if [ -z "$1" ]; then
+   echo "Please set base image name."
+   echo "e.g. $ stand_alone_test.sh debian:buster"
+   exit
+fi
+
+BASE_IMAGE=${1}
+
+rm libnginx-* -rf
+pushd ..
+docker build --build-arg base_image=${BASE_IMAGE} -t tmp_image -f packaging/deb.dockerfile .
+docker run --rm --mount "type=bind,source=$(pwd)/test,target=/nginx-sxg-module/output" tmp_image
+popd
+
+rm -rf out && mkdir out
+./generate.sh
+
+docker build --build-arg base_image=${BASE_IMAGE} -t nginx .
+docker run --mount type=bind,src=$(pwd)/out,dst=/data/result nginx
+
+cat out/error.log | grep content-type -i -q
+echo "${BASE_IMAGE}: Success."
+
+rm rm libnginx-* *.key *.crt -rf


### PR DESCRIPTION
fixes #4 
fixes #59

Append `X-Content-Type-Option: nosniff` automatically.
Now you don't have to configure nginx as `add_header X-Content-Type-Option nosniff` explicitly.

If there is the header already exists, it will automatically append it and results `X-Content-Type-Option: nosniff, nosniff`, but it is not harmful.

Also, remove duplicate signed headers from the outer headers.