### PR TITLE
feat: use loc_conf correctly

### DIFF
--- a/.github/workflows/end-to-end-test.yml
+++ b/.github/workflows/end-to-end-test.yml
@@ -35,6 +35,9 @@ jobs:
           mkdir out
           docker build --build-arg base_image=${{ matrix.names.base_image }} -t nginx .
           docker run --mount type=bind,src=$(pwd)/out,dst=/data/result nginx
+          test $(md5sum out/index.sxg) != "633a359d9e12522fe26a671927b989e8"
+          test $(md5sum out/index.html) == "633a359d9e12522fe26a671927b989e8"
+          test $(md5sum out/http.html) == "633a359d9e12522fe26a671927b989e8"
           popd
 
       - name: Extract results

--- a/ngx_http_sxg_filter_module.c
+++ b/ngx_http_sxg_filter_module.c
@@ -827,7 +827,7 @@ static ngx_int_t ngx_http_sxg_body_filter_impl(ngx_http_request_t* req,
   }
 
   sxg_header_append_string("content-type",
-                           (const char*)req->headers_out.content_type->data,
+                           (const char*)req->headers_out.content_type.data,
                            &ctx->response.header);
   static const char kSxgContentType[] = "application/signed-exchange;v=b3";
   ngx_str_set(&req->headers_out.content_type, kSxgContentType);  // must be SXG

--- a/ngx_http_sxg_filter_module.c
+++ b/ngx_http_sxg_filter_module.c
@@ -39,7 +39,7 @@ typedef struct {
   ngx_str_t cert_path;
   sxg_signer_list_t signers;
   ngx_sxg_cert_chain_t cert_chain;
-} ngx_http_sxg_srv_conf_t;
+} ngx_http_sxg_loc_conf_t;
 
 typedef struct {
   ngx_str_t url;
@@ -53,7 +53,7 @@ typedef struct {
   int subresources;
   int main_resource_loaded;
   sxg_raw_response_t response;
-  ngx_http_sxg_srv_conf_t* srv_conf;
+  ngx_http_sxg_loc_conf_t* loc_conf;
   bool cert_chain_mode;
   ngx_str_t link_header;
   ngx_array_t subresource_list;
@@ -65,45 +65,40 @@ typedef struct {
 static ngx_http_output_header_filter_pt ngx_http_next_header_filter;
 static ngx_http_output_body_filter_pt ngx_http_next_body_filter;
 static ngx_int_t ngx_http_sxg_filter_init(ngx_conf_t* cf);
-static void* ngx_http_sxg_create_srv_conf(ngx_conf_t* cf);
-static char* construct_fallback_url(const ngx_http_request_t* r);
-static char* ngx_http_sxg_merge_srv_conf(ngx_conf_t* cf, void* parent,
+static void* ngx_http_sxg_create_loc_conf(ngx_conf_t* cf);
+static char* ngx_http_sxg_merge_loc_conf(ngx_conf_t* cf, void* parent,
                                          void* child);
+static char* construct_fallback_url(const ngx_http_request_t* r);
 static ngx_int_t subresource_fetch_handler_impl(ngx_http_request_t* req,
                                                 ngx_http_core_srv_conf_t* cscf,
                                                 ngx_http_sxg_ctx_t* ctx);
 static ngx_int_t ngx_http_sxg_body_filter_impl(ngx_http_request_t* req,
                                                ngx_http_sxg_ctx_t* ctx,
                                                ngx_chain_t* in);
+static bool is_valid_config(ngx_conf_t* nc, const ngx_http_sxg_loc_conf_t* sc);
 
 static ngx_command_t ngx_http_sxg_commands[] = {
     {ngx_string("sxg"), NGX_HTTP_SRV_CONF | NGX_HTTP_LOC_CONF | NGX_CONF_FLAG,
-     ngx_conf_set_flag_slot, NGX_HTTP_SRV_CONF_OFFSET,
-     offsetof(ngx_http_sxg_srv_conf_t, enable), NULL},
-    {ngx_string("sxg_max_payload"),
-     NGX_HTTP_SRV_CONF | NGX_HTTP_LOC_CONF | NGX_CONF_TAKE1,
-     ngx_conf_set_size_slot, NGX_HTTP_SRV_CONF_OFFSET,
-     offsetof(ngx_http_sxg_srv_conf_t, sxg_max_payload), NULL},
-    {ngx_string("sxg_certificate"),
-     NGX_HTTP_SRV_CONF | NGX_HTTP_LOC_CONF | NGX_CONF_TAKE1,
-     ngx_conf_set_str_slot, NGX_HTTP_SRV_CONF_OFFSET,
-     offsetof(ngx_http_sxg_srv_conf_t, certificate), NULL},
-    {ngx_string("sxg_certificate_key"),
-     NGX_HTTP_SRV_CONF | NGX_HTTP_LOC_CONF | NGX_CONF_TAKE1,
-     ngx_conf_set_str_slot, NGX_HTTP_SRV_CONF_OFFSET,
-     offsetof(ngx_http_sxg_srv_conf_t, certificate_key), NULL},
-    {ngx_string("sxg_cert_url"),
-     NGX_HTTP_SRV_CONF | NGX_HTTP_LOC_CONF | NGX_CONF_TAKE1,
-     ngx_conf_set_str_slot, NGX_HTTP_SRV_CONF_OFFSET,
-     offsetof(ngx_http_sxg_srv_conf_t, cert_url), NULL},
-    {ngx_string("sxg_validity_url"),
-     NGX_HTTP_SRV_CONF | NGX_HTTP_LOC_CONF | NGX_CONF_TAKE1,
-     ngx_conf_set_str_slot, NGX_HTTP_SRV_CONF_OFFSET,
-     offsetof(ngx_http_sxg_srv_conf_t, validity_url), NULL},
-    {ngx_string("sxg_cert_path"),
-     NGX_HTTP_SRV_CONF | NGX_HTTP_LOC_CONF | NGX_CONF_TAKE1,
-     ngx_conf_set_str_slot, NGX_HTTP_SRV_CONF_OFFSET,
-     offsetof(ngx_http_sxg_srv_conf_t, cert_path), NULL},
+     ngx_conf_set_flag_slot, NGX_HTTP_LOC_CONF_OFFSET,
+     offsetof(ngx_http_sxg_loc_conf_t, enable), NULL},
+    {ngx_string("sxg_max_payload"), NGX_HTTP_SRV_CONF | NGX_CONF_TAKE1,
+     ngx_conf_set_size_slot, NGX_HTTP_LOC_CONF_OFFSET,
+     offsetof(ngx_http_sxg_loc_conf_t, sxg_max_payload), NULL},
+    {ngx_string("sxg_certificate"), NGX_HTTP_SRV_CONF | NGX_CONF_TAKE1,
+     ngx_conf_set_str_slot, NGX_HTTP_LOC_CONF_OFFSET,
+     offsetof(ngx_http_sxg_loc_conf_t, certificate), NULL},
+    {ngx_string("sxg_certificate_key"), NGX_HTTP_SRV_CONF | NGX_CONF_TAKE1,
+     ngx_conf_set_str_slot, NGX_HTTP_LOC_CONF_OFFSET,
+     offsetof(ngx_http_sxg_loc_conf_t, certificate_key), NULL},
+    {ngx_string("sxg_cert_url"), NGX_HTTP_SRV_CONF | NGX_CONF_TAKE1,
+     ngx_conf_set_str_slot, NGX_HTTP_LOC_CONF_OFFSET,
+     offsetof(ngx_http_sxg_loc_conf_t, cert_url), NULL},
+    {ngx_string("sxg_validity_url"), NGX_HTTP_SRV_CONF | NGX_CONF_TAKE1,
+     ngx_conf_set_str_slot, NGX_HTTP_LOC_CONF_OFFSET,
+     offsetof(ngx_http_sxg_loc_conf_t, validity_url), NULL},
+    {ngx_string("sxg_cert_path"), NGX_HTTP_SRV_CONF | NGX_CONF_TAKE1,
+     ngx_conf_set_str_slot, NGX_HTTP_LOC_CONF_OFFSET,
+     offsetof(ngx_http_sxg_loc_conf_t, cert_path), NULL},
     ngx_null_command};
 
 static ngx_http_module_t ngx_http_sxg_filter_module_ctx = {
@@ -113,11 +108,11 @@ static ngx_http_module_t ngx_http_sxg_filter_module_ctx = {
     NULL, /* create main configuration */
     NULL, /* init main configuration */
 
-    ngx_http_sxg_create_srv_conf, /* create server configuration */
-    ngx_http_sxg_merge_srv_conf,  /* merge server configuration */
+    NULL, /* create server configuration */
+    NULL, /* merge server configuration */
 
-    ngx_http_sxg_create_srv_conf, /* create location configuration */
-    ngx_http_sxg_merge_srv_conf,  /* merge location configuration */
+    ngx_http_sxg_create_loc_conf, /* create location configuration */
+    ngx_http_sxg_merge_loc_conf,  /* merge location configuration */
 };
 
 ngx_module_t ngx_http_sxg_filter_module = {
@@ -145,34 +140,96 @@ static char* str_to_null_terminated(ngx_pool_t* pool, const ngx_str_t* str) {
   return copied;
 }
 
-static void* ngx_http_sxg_create_srv_conf(ngx_conf_t* cf) {
-  ngx_http_sxg_srv_conf_t* ssc =
-      ngx_palloc(cf->pool, sizeof(ngx_http_sxg_srv_conf_t));
-  ssc->enable = NGX_CONF_UNSET;
-  ssc->sxg_max_payload = NGX_CONF_UNSET_SIZE;
-  ssc->certificate = (ngx_str_t){.data = NULL, .len = 0};
-  ssc->certificate_key = (ngx_str_t){.data = NULL, .len = 0};
-  ssc->cert_url = (ngx_str_t){.data = NULL, .len = 0};
-  ssc->validity_url = (ngx_str_t){.data = NULL, .len = 0};
-  ssc->cert_path = (ngx_str_t){.data = NULL, .len = 0};
-  ssc->cert_chain = ngx_sxg_empty_cert_chain();
-  ssc->signers = sxg_empty_signer_list();
-  return ssc;
+static void* ngx_http_sxg_create_loc_conf(ngx_conf_t* cf) {
+  ngx_http_sxg_loc_conf_t* slc =
+      ngx_palloc(cf->pool, sizeof(ngx_http_sxg_loc_conf_t));
+  slc->enable = NGX_CONF_UNSET;
+  slc->sxg_max_payload = NGX_CONF_UNSET_SIZE;
+  slc->certificate = (ngx_str_t){.data = NULL, .len = 0};
+  slc->certificate_key = (ngx_str_t){.data = NULL, .len = 0};
+  slc->cert_url = (ngx_str_t){.data = NULL, .len = 0};
+  slc->validity_url = (ngx_str_t){.data = NULL, .len = 0};
+  slc->cert_path = (ngx_str_t){.data = NULL, .len = 0};
+  slc->cert_chain = ngx_sxg_empty_cert_chain();
+  slc->signers = sxg_empty_signer_list();
+  return slc;
 }
 
-static char* ngx_http_sxg_merge_srv_conf(ngx_conf_t* cf, void* parent,
+static char* ngx_http_sxg_merge_loc_conf(ngx_conf_t* cf, void* parent,
                                          void* child) {
-  ngx_http_sxg_srv_conf_t* prev = parent;
-  ngx_http_sxg_srv_conf_t* conf = child;
-
+  ngx_http_sxg_loc_conf_t* prev = parent;
+  ngx_http_sxg_loc_conf_t* conf = child;
+  ngx_conf_merge_value(conf->enable, prev->enable, 0);
+  ngx_conf_merge_size_value(conf->sxg_max_payload, prev->sxg_max_payload,
+                            64 * 1024 * 1024);  // Limited to 64 MB
   ngx_conf_merge_str_value(conf->certificate, prev->certificate, "");
   ngx_conf_merge_str_value(conf->certificate_key, prev->certificate_key, "");
   ngx_conf_merge_str_value(conf->cert_url, prev->cert_url, "");
   ngx_conf_merge_str_value(conf->validity_url, prev->validity_url, "");
   ngx_conf_merge_str_value(conf->cert_path, prev->cert_path, "");
-  if (conf->signers.size == 0) {
-    conf->signers = prev->signers;
+
+  if (!is_valid_config(cf, conf)) {
+    if (conf->enable) {
+      return NGX_CONF_ERROR;
+    } else {
+      return NGX_OK;
+    }
   }
+
+  bool loaded = false;
+  if (prev->signers.size > 0) {
+    conf->signers = prev->signers;
+  } else {
+    EVP_PKEY* privkey =
+        load_private_key((const char*)conf->certificate_key.data);
+    if (privkey == NULL) {
+      ngx_log_error(NGX_LOG_EMERG, cf->log, 0,
+                    "nginx-sxg-module: failed to load private key at %V",
+                    &conf->certificate_key);
+      return NGX_CONF_ERROR;
+    }
+    X509* cert = load_x509_cert((const char*)conf->certificate.data);
+    if (cert == NULL) {
+      ngx_log_error(NGX_LOG_EMERG, cf->log, 0,
+                    "nginx-sxg-module: failed to load certificate at %V",
+                    &conf->certificate);
+      return NGX_CONF_ERROR;
+    }
+    if (!sxg_add_ecdsa_signer("nginx", /*date=*/0, /*expires=*/0,
+                              (const char*)conf->validity_url.data, privkey,
+                              cert, (const char*)conf->cert_url.data,
+                              &conf->signers)) {
+      ngx_log_error(NGX_LOG_EMERG, cf->log, 0,
+                    "nginx-sxg-module: failed to allocate memory");
+      return NGX_CONF_ERROR;
+    }
+    loaded = true;
+    EVP_PKEY_free(privkey);
+    X509_free(cert);
+  }
+
+  if (prev->cert_chain.certificate != NULL && prev->cert_chain.issuer != NULL) {
+    conf->cert_chain = prev->cert_chain;
+  } else {
+    if (conf->cert_path.len > 0 &&
+        !load_cert_chain((const char*)conf->certificate.data,
+                         &conf->cert_chain)) {
+      return NGX_CONF_ERROR;
+    }
+  }
+
+  if (loaded) {
+    ngx_log_error(NGX_LOG_NOTICE, cf->log, 0,
+                  "nginx-sxg-module: successfully started with below settings\n"
+                  "SXG Certificate: %V\n"
+                  "SXG PrivateKey: %V\n"
+                  "certificate_url: %V\n"
+                  "validity_url: %V\n"
+                  "cert_path: %V",
+                  &conf->certificate, &conf->certificate_key, &conf->cert_url,
+                  &conf->validity_url, &conf->cert_path);
+  }
+
   return NGX_OK;
 }
 
@@ -197,11 +254,11 @@ static bool response_should_be_sxg(const ngx_http_request_t* const req) {
 
 static bool generate_sxg(const ngx_http_request_t* req,
                          const ngx_http_sxg_ctx_t* ctx, sxg_buffer_t* sxg) {
-  ngx_http_sxg_srv_conf_t* ssc =
-      ngx_http_get_module_srv_conf(req, ngx_http_sxg_filter_module);
+  ngx_http_sxg_loc_conf_t* slc =
+      ngx_http_get_module_loc_conf(req, ngx_http_sxg_filter_module);
 
   // Set parameters.
-  sxg_signer_t* const signer = &ssc->signers.signers[0];
+  sxg_signer_t* const signer = &slc->signers.signers[0];
   signer->date = time(NULL);
   signer->expires = signer->date + 60 * 60 * 24;
 
@@ -210,7 +267,7 @@ static bool generate_sxg(const ngx_http_request_t* req,
   sxg_encoded_response_t content = sxg_empty_encoded_response();
   bool success = fallback_url != NULL &&
                  sxg_encode_response(4096, &ctx->response, &content) &&
-                 sxg_generate(fallback_url, &ssc->signers, &content, sxg);
+                 sxg_generate(fallback_url, &slc->signers, &content, sxg);
   sxg_encoded_response_release(&content);
   ngx_pfree(req->pool, fallback_url);
 
@@ -255,13 +312,13 @@ static bool copy_response_header_to_sxg_header(ngx_pool_t* pool,
 
 static bool calc_integrity(const ngx_http_request_t* const req,
                            sxg_buffer_t* dst) {
-  ngx_http_sxg_srv_conf_t* ssc =
-      ngx_http_get_module_srv_conf(req, ngx_http_sxg_filter_module);
+  ngx_http_sxg_loc_conf_t* slc =
+      ngx_http_get_module_loc_conf(req, ngx_http_sxg_filter_module);
   sxg_raw_response_t response = sxg_empty_raw_response();
   const ngx_str_t* content_type = &req->headers_out.content_type;
   sxg_encoded_response_t content = sxg_empty_encoded_response();
   const size_t payload_size = req->out->buf->last - req->out->buf->pos;
-  if (ssc->sxg_max_payload < payload_size) {
+  if (slc->sxg_max_payload < payload_size) {
     sxg_buffer_release(dst);
     return false;
   }
@@ -544,14 +601,14 @@ static bool invoke_subrequests(ngx_str_t* link, ngx_http_request_t* req,
 
 static ngx_int_t ngx_http_sxg_header_filter(ngx_http_request_t* req) {
   // Called on every HTTP request.
-  ngx_http_sxg_srv_conf_t* ssc =
-      ngx_http_get_module_srv_conf(req, ngx_http_sxg_filter_module);
-  if (!ssc->enable) {
+  ngx_http_sxg_loc_conf_t* slc =
+      ngx_http_get_module_loc_conf(req, ngx_http_sxg_filter_module);
+  if (!slc->enable) {
     return ngx_http_next_header_filter(req);
   }
 
-  if (ssc->cert_path.len > 0 && req->uri.len == ssc->cert_path.len &&
-      ngx_memcmp(req->uri.data, ssc->cert_path.data, req->uri.len) == 0) {
+  if (slc->cert_path.len > 0 && req->uri.len == slc->cert_path.len &&
+      ngx_memcmp(req->uri.data, slc->cert_path.data, req->uri.len) == 0) {
     int rc = ngx_http_send_header(req);
     if (rc == NGX_ERROR || rc > NGX_OK || req->header_only) {
       return rc;
@@ -559,7 +616,7 @@ static ngx_int_t ngx_http_sxg_header_filter(ngx_http_request_t* req) {
     return NGX_OK;
   }
 
-  if (!ssc->enable || !response_should_be_sxg(req) || req->header_only ||
+  if (!response_should_be_sxg(req) || req->header_only ||
       (req->method & NGX_HTTP_HEAD) || req != req->main ||
       req->headers_out.status == NGX_HTTP_NO_CONTENT || req->parent != NULL) {
     return ngx_http_next_header_filter(req);
@@ -736,8 +793,8 @@ static ngx_int_t ngx_http_sxg_body_filter(ngx_http_request_t* req,
 static ngx_int_t ngx_http_sxg_body_filter_impl(ngx_http_request_t* req,
                                                ngx_http_sxg_ctx_t* ctx,
                                                ngx_chain_t* in) {
-  ngx_http_sxg_srv_conf_t* ssc =
-      ngx_http_get_module_srv_conf(req, ngx_http_sxg_filter_module);
+  ngx_http_sxg_loc_conf_t* slc =
+      ngx_http_get_module_loc_conf(req, ngx_http_sxg_filter_module);
 
   if (req->header_sent) {
     return ngx_http_next_body_filter(req, in);
@@ -745,7 +802,7 @@ static ngx_int_t ngx_http_sxg_body_filter_impl(ngx_http_request_t* req,
   if (!ctx->main_resource_loaded) {
     bool lastbuf_included = false;
     if (copy_buffer_to_sxg_buffer(req, in, &ctx->response.payload,
-                                  ssc->sxg_max_payload, &lastbuf_included)) {
+                                  slc->sxg_max_payload, &lastbuf_included)) {
       if (lastbuf_included) {
         // Whole main resource body copied.
         ctx->main_resource_loaded = true;
@@ -808,40 +865,48 @@ static ngx_int_t ngx_http_sxg_body_filter_impl(ngx_http_request_t* req,
   return ngx_http_next_body_filter(req, out);
 }
 
-static bool is_valid_config(ngx_conf_t* nc, const ngx_http_sxg_srv_conf_t* sc) {
+static bool is_valid_config(ngx_conf_t* nc, const ngx_http_sxg_loc_conf_t* sc) {
   bool valid = true;
   if (sc->certificate.len == 0) {
     valid = false;
-    ngx_log_error(NGX_LOG_CRIT, nc->log, 0,
-                  "nginx-sxg-module: sxg_certificate not specified");
+    if (sc->enable) {
+      ngx_log_error(NGX_LOG_CRIT, nc->log, 0,
+                    "nginx-sxg-module: sxg_certificate not specified");
+    }
   }
   if (sc->certificate_key.len == 0) {
     valid = false;
-    ngx_log_error(NGX_LOG_CRIT, nc->log, 0,
-                  "nginx-sxg-module: sxg_certificate_key not specified");
+    if (sc->enable) {
+      ngx_log_error(NGX_LOG_CRIT, nc->log, 0,
+                    "nginx-sxg-module: sxg_certificate_key not specified");
+    }
   }
   if (sc->validity_url.len == 0) {
     valid = false;
-    ngx_log_error(NGX_LOG_CRIT, nc->log, 0,
-                  "nginx-sxg-module: sxg_validity_url not specified");
+    if (sc->enable) {
+      ngx_log_error(NGX_LOG_CRIT, nc->log, 0,
+                    "nginx-sxg-module: sxg_validity_url not specified");
+    }
   }
   if (sc->cert_url.len == 0) {
     valid = false;
-    ngx_log_error(NGX_LOG_CRIT, nc->log, 0,
-                  "nginx-sxg-module: sxg_certificate_url not specified");
+    if (sc->enable) {
+      ngx_log_error(NGX_LOG_CRIT, nc->log, 0,
+                    "nginx-sxg-module: sxg_certificate_url not specified");
+    }
   }
   return valid;
 }
 
 static ngx_int_t ngx_http_cert_chain_handler(ngx_http_request_t* req) {
   // Check the URL is a certificate request.
-  ngx_http_sxg_srv_conf_t* ssc =
-      ngx_http_get_module_srv_conf(req, ngx_http_sxg_filter_module);
-  if (ssc->cert_path.len <= 0 || req->uri.len != ssc->cert_path.len ||
-      ngx_memcmp(req->uri.data, ssc->cert_path.data, req->uri.len) != 0) {
+  ngx_http_sxg_loc_conf_t* slc =
+      ngx_http_get_module_loc_conf(req, ngx_http_sxg_filter_module);
+  if (slc->cert_path.len <= 0 || req->uri.len != slc->cert_path.len ||
+      ngx_memcmp(req->uri.data, slc->cert_path.data, req->uri.len) != 0) {
     return NGX_OK;
   }
-  bool refreshed = refresh_if_needed(&ssc->cert_chain);
+  bool refreshed = refresh_if_needed(&slc->cert_chain);
   if (refreshed) {
     ngx_log_error(
         NGX_LOG_INFO, req->connection->log, 0,
@@ -849,14 +914,14 @@ static ngx_int_t ngx_http_cert_chain_handler(ngx_http_request_t* req) {
   }
   req->headers_out.status = NGX_HTTP_OK;
   req->headers_out.content_length_n =
-      ssc->cert_chain.serialized_cert_chain.size;
+      slc->cert_chain.serialized_cert_chain.size;
 
   ngx_str_set(&req->headers_out.content_type, "application/cert-chain+cbor");
   req->headers_out.content_type_len = req->headers_out.content_type.len;
   req->headers_out.content_type_lowcase = NULL;
 
   ngx_chain_t* out;
-  if (!make_chain_from_buffer(req, &ssc->cert_chain.serialized_cert_chain,
+  if (!make_chain_from_buffer(req, &slc->cert_chain.serialized_cert_chain,
                               &out)) {
     ngx_log_error(NGX_LOG_ERR, req->connection->log, 0,
                   "nginx-sxg-module: failed to generate Cert-Chain.");
@@ -874,69 +939,6 @@ static ngx_int_t ngx_http_cert_chain_handler(ngx_http_request_t* req) {
 static ngx_int_t ngx_http_sxg_filter_init(ngx_conf_t* cf) {
   ngx_http_core_main_conf_t* cmcf =
       ngx_http_conf_get_module_main_conf(cf, ngx_http_core_module);
-  ngx_http_core_srv_conf_t** cscfp = cmcf->servers.elts;
-
-  for (unsigned int s = 0; s < cmcf->servers.nelts; s++) {
-    ngx_http_sxg_srv_conf_t* nscf =
-        cscfp[s]->ctx->srv_conf[ngx_http_sxg_filter_module.ctx_index];
-    if (nscf->enable == NGX_CONF_UNSET || nscf->enable == 0) {
-      return NGX_OK;
-    }
-
-    nscf->signers = sxg_empty_signer_list();
-    if (nscf->sxg_max_payload == NGX_CONF_UNSET_SIZE) {
-      nscf->sxg_max_payload = 64 * 1024 * 1024;  // Limited to 64 MB
-    }
-
-    if (!is_valid_config(cf, nscf)) {
-      ngx_log_error(NGX_LOG_EMERG, cf->log, 0,
-                    "nginx-sxg-module: invalid config");
-      return NGX_ERROR;
-    }
-
-    EVP_PKEY* privkey =
-        load_private_key((const char*)nscf->certificate_key.data);
-    if (privkey == NULL) {
-      ngx_log_error(NGX_LOG_EMERG, cf->log, 0,
-                    "nginx-sxg-module: failed to load private key at %V",
-                    &nscf->certificate_key);
-      return NGX_ERROR;
-    }
-    X509* cert = load_x509_cert((const char*)nscf->certificate.data);
-    if (cert == NULL) {
-      ngx_log_error(NGX_LOG_EMERG, cf->log, 0,
-                    "nginx-sxg-module: failed to load certificate at %V",
-                    &nscf->certificate);
-      return NGX_ERROR;
-    }
-
-    if (!sxg_add_ecdsa_signer("nginx", /*date=*/0, /*expires=*/0,
-                              (const char*)nscf->validity_url.data, privkey,
-                              cert, (const char*)nscf->cert_url.data,
-                              &nscf->signers)) {
-      ngx_log_error(NGX_LOG_EMERG, cf->log, 0,
-                    "nginx-sxg-module: failed to allocate memory");
-      return NGX_ERROR;
-    }
-    if (nscf->cert_path.len > 0 &&
-        !load_cert_chain((const char*)nscf->certificate.data,
-                         &nscf->cert_chain)) {
-      return NGX_ERROR;
-    }
-
-    ngx_log_error(NGX_LOG_NOTICE, cf->log, 0,
-                  "nginx-sxg-module: successfully started with below settings\n"
-                  "SXG Certificate: %V\n"
-                  "SXG PrivateKey: %V\n"
-                  "certificate_url: %V\n"
-                  "validity_url: %V\n"
-                  "cert_path: %V",
-                  &nscf->certificate, &nscf->certificate_key, &nscf->cert_url,
-                  &nscf->validity_url, &nscf->cert_path);
-
-    EVP_PKEY_free(privkey);
-    X509_free(cert);
-  }
 
   ngx_http_next_header_filter = ngx_http_top_header_filter;
   ngx_http_top_header_filter = ngx_http_sxg_header_filter;

--- a/test/Dockerfile
+++ b/test/Dockerfile
@@ -18,6 +18,8 @@ COPY sxg.crt .
 COPY sxg.key .
 COPY nginx-sxg.conf /etc/nginx/sites-enabled/
 COPY index.html /var/www/nginx-sxg.test/
+COPY index.html /var/www/nginx-sxg.test/foo/
+COPY index.html /var/www/nginx-sxg.test/bar/
 RUN mkdir result
 RUN chmod 755 -R /var/www/nginx-sxg.test/
 

--- a/test/nginx-sxg.conf
+++ b/test/nginx-sxg.conf
@@ -18,6 +18,25 @@ server {
        # So, do not enable this line.
        # sxg_cert_path       /cert.cbor;  
 
+	   location /bar {
+	   	  sxg on;
+		  root /var/www/nginx-sxg.test;
+		  index index.html;
+	   }
+
+	   location /foo {
+	   	  sxg off;
+		  root /var/www/nginx-sxg.test;
+		  index index.html;
+	   }
+}
+
+server {
+       listen 8080;
+       server_name         nginx-no-sxg.test;
+       error_log           /var/log/nginx/error.log debug;
+       rewrite_log         on;
+
        root /var/www/nginx-sxg.test;
        index index.html;
 }

--- a/test/selfcheck.sh
+++ b/test/selfcheck.sh
@@ -11,7 +11,9 @@ fi
 
 rm -rf out
 mkdir out
-curl -H"Host:nginx-sxg.test" -H"Accept:application/signed-exchange;v=b3" https://127.0.0.1/ -k --output - > /data/result/index.sxg
+curl -H"Host:nginx-sxg.test" -H"Accept:application/signed-exchange;v=b3" https://127.0.0.1/bar/ -k --output - > /data/result/index.sxg
+curl -H"Host:nginx-sxg.test" -H"Accept:application/signed-exchange;v=b3" https://127.0.0.1/foo/ -k --output - > /data/result/index.html
+curl -H"Host:nginx-no-sxg.test" -H"Accept:application/signed-exchange;v=b3" http://127.0.0.1:8080/ -k --output - > /data/result/http.html
 cp /var/log/nginx/error.log /data/result/
 chmod -R 755 /data/result
 


### PR DESCRIPTION
fix #48
fix #50

use loc_conf for to fix #50.
and I moved the config validation logic to ngx_http_sxg_merge_loc_conf. it is a standard way.
the root cause of #48 is here.
https://github.com/google/nginx-sxg-module/blob/0ffe86cae9b1d54179327d70ac2c48e848a1f63d/ngx_http_sxg_filter_module.c#L911-L913
Maybe "continue" is correct. I removed it.