### PR TITLE
chore: fix the end to end test script

### DIFF
--- a/.github/workflows/end-to-end-test.yml
+++ b/.github/workflows/end-to-end-test.yml
@@ -35,9 +35,9 @@ jobs:
           mkdir out
           docker build --build-arg base_image=${{ matrix.names.base_image }} -t nginx .
           docker run --mount type=bind,src=$(pwd)/out,dst=/data/result nginx
-          test $(md5sum out/index.sxg) != "633a359d9e12522fe26a671927b989e8"
-          test $(md5sum out/index.html) == "633a359d9e12522fe26a671927b989e8"
-          test $(md5sum out/http.html) == "633a359d9e12522fe26a671927b989e8"
+          test $(md5sum out/index.sxg | awk '{print $1}') != "633a359d9e12522fe26a671927b989e8"
+          test $(md5sum out/index.html | awk '{print $1}') == "633a359d9e12522fe26a671927b989e8"
+          test $(md5sum out/http.html | awk '{print $1}') == "633a359d9e12522fe26a671927b989e8"
           popd
 
       - name: Extract results


### PR DESCRIPTION
sorry, it is my mistake. md5sum does not outputs only the hash value.