### PR TITLE
add Vary: Accept header in outer HTTP response

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,8 +84,6 @@ http {
     server {
         listen    80;
         server_name  example.com;
-        add_header X-Content-Type-Options nosniff;
-        add_header Vary Accept;
 
         sxg on;
         sxg_certificate     /path/to/certificate-ecdsa.pem;

--- a/ngx_http_sxg_filter_module.c
+++ b/ngx_http_sxg_filter_module.c
@@ -852,8 +852,7 @@ static ngx_int_t ngx_http_sxg_body_filter_impl(ngx_http_request_t* req,
   x_content_type_options->hash = 1;
   ngx_str_set(&x_content_type_options->key, "X-Content-Type-Options");
   ngx_str_set(&x_content_type_options->value, "nosniff");
-  ngx_table_elt_t* vary =
-      ngx_list_push(&req->headers_out.headers);
+  ngx_table_elt_t* vary = ngx_list_push(&req->headers_out.headers);
   vary->hash = 1;
   ngx_str_set(&vary->key, "Vary");
   ngx_str_set(&vary->value, "Accept");

--- a/ngx_http_sxg_filter_module.c
+++ b/ngx_http_sxg_filter_module.c
@@ -833,7 +833,7 @@ static ngx_int_t ngx_http_sxg_body_filter_impl(ngx_http_request_t* req,
 
   // Cleanup outer headers and trailers.
   ngx_memzero(&req->headers_out, sizeof(ngx_http_headers_out_t));
-  if (ngx_list_init(&req->headers_out.headers, req->pool, 1,
+  if (ngx_list_init(&req->headers_out.headers, req->pool, 2,
                     sizeof(ngx_table_elt_t)) != NGX_OK) {
     ngx_log_error(NGX_LOG_ERR, req->connection->log, 0,
                   "nginx-sxg-module: failed to initialize outer header list");
@@ -852,6 +852,11 @@ static ngx_int_t ngx_http_sxg_body_filter_impl(ngx_http_request_t* req,
   x_content_type_options->hash = 1;
   ngx_str_set(&x_content_type_options->key, "X-Content-Type-Options");
   ngx_str_set(&x_content_type_options->value, "nosniff");
+  ngx_table_elt_t* vary =
+      ngx_list_push(&req->headers_out.headers);
+  vary->hash = 1;
+  ngx_str_set(&vary->key, "Vary");
+  ngx_str_set(&vary->value, "Accept");
 
   // Modify out of list outer header entries.
   ngx_str_set(&req->headers_out.content_type,

--- a/test/expected_header
+++ b/test/expected_header
@@ -1,0 +1,6 @@
+HTTP/1.1 000
+Content-Type: application/signed-exchange;v=b3
+Content-Length: 682
+Connection: keep-alive
+X-Content-Type-Options: nosniff
+Vary: Accept


### PR DESCRIPTION
fixes #3 

Now, this module will add `Vary: Accept` header as it does.
Users don't need to append `add_header vary: accept` directive in their configure anymore.
But if user already appended it, `Vary: Accept,Accept` will be harmless in result.