### PR TITLE
fix: fixed the method of determining if the content is fully loaded

### DIFF
--- a/ngx_http_sxg_filter_module.c
+++ b/ngx_http_sxg_filter_module.c
@@ -369,7 +369,12 @@ static ngx_int_t subresource_fetch_handler_impl(ngx_http_request_t* req,
     --ctx->subresources;
     return NGX_OK;
   }
-  if (req->out->buf->last - req->out->buf->pos == req->upstream->length) {
+  ngx_log_error(NGX_LOG_DEBUG, req->connection->log, 0,
+                "nginx-sxg-module: Subresource fetched. bytes=%l/%l",
+                req->out->buf->last - req->out->buf->pos,
+                req->upstream->length);
+  if (req->out->buf->last - req->out->buf->pos == req->upstream->length ||
+      req->upstream->length == -1) {
     ngx_http_set_ctx(req, ctx, ngx_http_sxg_filter_module);
     sxg_buffer_t url = sxg_empty_buffer();
 

--- a/ngx_http_sxg_filter_module.c
+++ b/ngx_http_sxg_filter_module.c
@@ -373,6 +373,8 @@ static ngx_int_t subresource_fetch_handler_impl(ngx_http_request_t* req,
                 "nginx-sxg-module: Subresource fetched. bytes=%l/%l",
                 req->out->buf->last - req->out->buf->pos,
                 req->upstream->length);
+
+  // if the request hit the proxy cache, req->upstream->length is -1.
   if (req->out->buf->last - req->out->buf->pos == req->upstream->length ||
       req->upstream->length == -1) {
     ngx_http_set_ctx(req, ctx, ngx_http_sxg_filter_module);


### PR DESCRIPTION
fix #51
if the request hit the proxy cache, req->upstream->length is -1.