### PR TITLE
admit OWS between `rel` and `=` in HTTP header. (#53)

### DIFF
--- a/ngx_sxg_utils_test.cc
+++ b/ngx_sxg_utils_test.cc
@@ -78,8 +78,10 @@ TEST(NgxSxgUtilsTest, ParamIsPreload) {
   EXPECT_TRUE(ParamIsPreload(" rel=preload"));
   EXPECT_TRUE(ParamIsPreload("rel=preload "));
   EXPECT_TRUE(ParamIsPreload("rel= preload"));
+  EXPECT_TRUE(ParamIsPreload("rel =preload"));
   EXPECT_TRUE(ParamIsPreload("rel=\" preload\""));
   EXPECT_TRUE(ParamIsPreload("rel=\"preload \""));
+  EXPECT_TRUE(ParamIsPreload("rel= \"preload\""));
   EXPECT_TRUE(ParamIsPreload(R"(rel="preload")"));
   EXPECT_TRUE(ParamIsPreload(R"(rel="alter preload hello world")"));
   EXPECT_FALSE(ParamIsPreload("preload=rel"));
@@ -90,10 +92,9 @@ TEST(NgxSxgUtilsTest, ParamIsPreload) {
   EXPECT_FALSE(ParamIsPreload("rel= "));
   EXPECT_FALSE(ParamIsPreload("rel=\"\n \""));
   EXPECT_FALSE(ParamIsPreload("r"));
+  EXPECT_FALSE(ParamIsPreload("rel=preloa"));
   EXPECT_FALSE(ParamIsPreload("rel=prepreload"));
-
-  // TODO: we should support this pattern.
-  // EXPECT_TRUE(ParamIsPreload("rel =preload"));
+  EXPECT_FALSE(ParamIsPreload("rel = \"\"preload\""));
 }
 
 bool ParamIsAs(const std::string& input, const std::string& value) {
@@ -107,17 +108,19 @@ TEST(NgxSxgUtilsTest, ParamIsAs) {
   EXPECT_TRUE(ParamIsAs("as=script", "script"));
   EXPECT_TRUE(ParamIsAs("as=image", "image"));
   EXPECT_TRUE(ParamIsAs("as= script", "script"));
+  EXPECT_TRUE(ParamIsAs("as =script", "script"));
   EXPECT_TRUE(ParamIsAs("as=script ", "script"));
   EXPECT_TRUE(ParamIsAs(" as=script", "script"));
   EXPECT_TRUE(ParamIsAs("as=\"script\"", "script"));
   EXPECT_TRUE(ParamIsAs("as=\" script\"", "script"));
   EXPECT_TRUE(ParamIsAs("as=\"script \"", "script"));
+  EXPECT_FALSE(ParamIsAs("as=\" \"", ""));
+  EXPECT_FALSE(ParamIsAs("as=\"", ""));
+  EXPECT_FALSE(ParamIsAs("as= ", ""));
+  EXPECT_FALSE(ParamIsAs("as!=script", ""));
   EXPECT_FALSE(ParamIsAs("as=script", "image"));
   EXPECT_FALSE(ParamIsAs("is=script", "script"));
   EXPECT_FALSE(ParamIsAs("as=scrpt", "script"));
-
-  // TODO(kumagi): we should support this pattern.
-  // EXPECT_TRUE(ParamIsPreload("as =script"));
 }
 
 TEST(NgxSxgCertChain, free) {


### PR DESCRIPTION
1. Modify 'rel'/'as' parser logics to support OWS
2. Add boundary check to 'quoted_string_match'
3. Add boundary check to 'strip'
4. Add test cases for new parser logics