### PR TITLE
add expires_seconds directive

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,6 +68,11 @@ An absolute path in which nginx will generate and serve the CBOR-encoded certifi
 But make sure that the OCSP responder for the certificate is accessible from your nginx server to get OCSP responses.
 This directive is optional.
 
+#### sxg\_expires\_seconds
+
+The life-span of SXG file in seconds. It must not be more than 604800 (1 weeek).
+This directive is optional. The default value is `86400` (1 day).
+
 ### Config Example
 
 ```
@@ -90,6 +95,7 @@ http {
         sxg_certificate_key /path/to/private-key-ecdsa.key;
         sxg_cert_url        https://cdn.test.com/example.com.cert.cbor;
         sxg_validity_url    https://example.com/validity/resource.msg;
+        sxg_expires_seconds 604800;
 
         location / {
             proxy_pass http://app;

--- a/README.md
+++ b/README.md
@@ -68,10 +68,12 @@ An absolute path in which nginx will generate and serve the CBOR-encoded certifi
 But make sure that the OCSP responder for the certificate is accessible from your nginx server to get OCSP responses.
 This directive is optional.
 
-#### sxg\_expires\_seconds
+#### sxg\_expiry\_seconds
 
-The life-span of SXG file in seconds. It must not be more than 604800 (1 weeek).
-This directive is optional. The default value is `86400` (1 day).
+The life-span of generated SXG file in seconds.
+It must not be bigger than 604800 (1 week).
+This directive is optional.
+The default value is `86400` (1 day).
 
 ### Config Example
 

--- a/ngx_http_sxg_filter_module.c
+++ b/ngx_http_sxg_filter_module.c
@@ -37,6 +37,7 @@ typedef struct {
   ngx_str_t cert_url;
   ngx_str_t validity_url;
   ngx_str_t cert_path;
+  size_t expires_seconds;
   sxg_signer_list_t signers;
   ngx_sxg_cert_chain_t cert_chain;
 } ngx_http_sxg_loc_conf_t;
@@ -99,6 +100,9 @@ static ngx_command_t ngx_http_sxg_commands[] = {
     {ngx_string("sxg_cert_path"), NGX_HTTP_SRV_CONF | NGX_CONF_TAKE1,
      ngx_conf_set_str_slot, NGX_HTTP_LOC_CONF_OFFSET,
      offsetof(ngx_http_sxg_loc_conf_t, cert_path), NULL},
+    {ngx_string("sxg_expires_seconds"), NGX_HTTP_SRV_CONF | NGX_CONF_TAKE1,
+     ngx_conf_set_size_slot, NGX_HTTP_LOC_CONF_OFFSET,
+     offsetof(ngx_http_sxg_loc_conf_t, expires_seconds), NULL},
     ngx_null_command};
 
 static ngx_http_module_t ngx_http_sxg_filter_module_ctx = {
@@ -151,6 +155,7 @@ static void* ngx_http_sxg_create_loc_conf(ngx_conf_t* cf) {
   slc->validity_url = (ngx_str_t){.data = NULL, .len = 0};
   slc->cert_path = (ngx_str_t){.data = NULL, .len = 0};
   slc->cert_chain = ngx_sxg_empty_cert_chain();
+  slc->expires_seconds = NGX_CONF_UNSET_SIZE;
   slc->signers = sxg_empty_signer_list();
   return slc;
 }
@@ -167,6 +172,8 @@ static char* ngx_http_sxg_merge_loc_conf(ngx_conf_t* cf, void* parent,
   ngx_conf_merge_str_value(conf->cert_url, prev->cert_url, "");
   ngx_conf_merge_str_value(conf->validity_url, prev->validity_url, "");
   ngx_conf_merge_str_value(conf->cert_path, prev->cert_path, "");
+  ngx_conf_merge_size_value(conf->expires_seconds, prev->expires_seconds,
+                            60 * 60 * 24);  // 1 day.
 
   if (!is_valid_config(cf, conf)) {
     if (conf->enable) {
@@ -218,6 +225,14 @@ static char* ngx_http_sxg_merge_loc_conf(ngx_conf_t* cf, void* parent,
     }
   }
 
+  if (conf->expires_seconds > 60 * 60 * 24 * 7) {
+    // SXG life-span longer than 7 days is not allowed by spec.
+    ngx_log_error(NGX_LOG_EMERG, cf->log, 0,
+                  "nginx-sxg-module: too long lifespan of SXG %d seconds",
+                  conf->expires_seconds);
+    return NGX_CONF_ERROR;
+  }
+
   if (loaded) {
     ngx_log_error(NGX_LOG_NOTICE, cf->log, 0,
                   "nginx-sxg-module: successfully started with below settings\n"
@@ -260,7 +275,7 @@ static bool generate_sxg(const ngx_http_request_t* req,
   // Set parameters.
   sxg_signer_t* const signer = &slc->signers.signers[0];
   signer->date = time(NULL);
-  signer->expires = signer->date + 60 * 60 * 24;
+  signer->expires = signer->date + slc->expires_seconds;
 
   // Generate SXG.
   char* const fallback_url = construct_fallback_url(req);


### PR DESCRIPTION
Closes #75 
SXG life-span should be configurable in the range of spec (maximum 7 days).
So I appended `sxg_expires_seconds` directive.