### PR TITLE
fix: typo in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -97,7 +97,7 @@ http {
         sxg_certificate_key /path/to/private-key-ecdsa.key;
         sxg_cert_url        https://cdn.test.com/example.com.cert.cbor;
         sxg_validity_url    https://example.com/validity/resource.msg;
-        sxg_expires_seconds 604800;
+        sxg_expiry_seconds 604800;
 
         location / {
             proxy_pass http://app;


### PR DESCRIPTION
directive `sxg_expires_seconds` is not available in this module anymore.

Config Example in README.md was remained to correct `sxg_expires_seconds` to `sxg_expiry_seconds`.