### PR TITLE
Update non-LTS release to the latest.

### DIFF
--- a/.github/workflows/clang-format-validation.yml
+++ b/.github/workflows/clang-format-validation.yml
@@ -2,7 +2,7 @@ name: Validate code format with clang-format
 on: [push, pull_request]
 jobs:
   validate:
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v2
 

--- a/.github/workflows/end-to-end-test.yml
+++ b/.github/workflows/end-to-end-test.yml
@@ -9,10 +9,10 @@ jobs:
         names:
           - base_image: "ubuntu:bionic"
             image_name: "bionic"
-          - base_image: "ubuntu:eoan"
-            image_name: "eoan"
           - base_image: "ubuntu:focal"
             image_name: "focal"
+          - base_image: "ubuntu:groovy"
+            image_name: "groovy"
           - base_image: "debian:buster"
             image_name: "buster"
     steps:

--- a/.github/workflows/make-debs.yml
+++ b/.github/workflows/make-debs.yml
@@ -9,10 +9,10 @@ jobs:
         names:
           - base_image: "ubuntu:bionic"
             image_name: "bionic"
-          - base_image: "ubuntu:eoan"
-            image_name: "eoan"
           - base_image: "ubuntu:focal"
             image_name: "focal"
+          - base_image: "ubuntu:groovy"
+            image_name: "groovy"
           - base_image: "debian:buster"
             image_name: "buster"
     steps:

--- a/.github/workflows/release-action.yml
+++ b/.github/workflows/release-action.yml
@@ -9,10 +9,10 @@ jobs:
         names:
           - base_image: "ubuntu:bionic"
             image_name: "bionic"
-          - base_image: "ubuntu:eoan"
-            image_name: "eoan"
           - base_image: "ubuntu:focal"
             image_name: "focal"
+          - base_image: "ubuntu:groovy"
+            image_name: "groovy"
           - base_image: "debian:buster"
             image_name: "buster"
     steps:


### PR DESCRIPTION
Update 3 github workflows to use 2 latest LTS releases and 1 latest
non-LTS release of Ubuntu. Updated clang-format to use ubuntu-latest
instead of 18.04.

Fixes #85.

/cc @orisano 