### PR TITLE
feat: add sxg_fallback_host option

### DIFF
--- a/.github/workflows/end-to-end-test.yml
+++ b/.github/workflows/end-to-end-test.yml
@@ -51,7 +51,7 @@ jobs:
 
       - name: Check status code to be 200
         run: |
-          if [ "$(head -n1 test/out/index.header)" != "HTTP/1.1 200" ]; then exit 1; fi
+          if [ "$(head -n1 test/out/index.header)" != "HTTP/1.1 200 OK" ]; then exit 1; fi
 
       - name: Upload artifacts
         uses: actions/upload-artifact@v1

--- a/README.md
+++ b/README.md
@@ -79,7 +79,7 @@ The default value is `86400` (1 day).
 
 The hostname of fallback url of generated SXG file.
 This directive is optional.
-The default value is use `Host` header field value.
+The default value is Host field parameter of HTTP request header.
 
 ### Config Example
 

--- a/README.md
+++ b/README.md
@@ -75,6 +75,12 @@ It must not be bigger than 604800 (1 week).
 This directive is optional.
 The default value is `86400` (1 day).
 
+#### sxg\_fallback\_host
+
+The hostname of fallback url of generated SXG file.
+This directive is optional.
+The default value is use `Host` header field value.
+
 ### Config Example
 
 ```
@@ -98,6 +104,7 @@ http {
         sxg_cert_url        https://cdn.test.com/example.com.cert.cbor;
         sxg_validity_url    https://example.com/validity/resource.msg;
         sxg_expiry_seconds 604800;
+        sxg_fallback_host  example.com;
 
         location / {
             proxy_pass http://app;


### PR DESCRIPTION
We want to specify a fallback URL origin manually.

## Background

![architecture](https://user-images.githubusercontent.com/1029249/108090725-49409b00-70be-11eb-9e19-c4d32fdd42a7.png)

Currently, this module uses the `Host` header field's value to construct the fallback URL.
In this case, the fallback URL's origin is `origin.example.com`.
We have to specify the validity URL's origin to `example.com`. (cannot access origin from the internet)

But "validity-url" parameter is must be same-origin with requestUrl (fallback URL).

> If the signature's "validity-url" parameter (Section 3.1) is not same-origin with requestUrl, return "invalid".

https://wicg.github.io/webpackage/draft-yasskin-http-origin-signed-responses.html#cross-origin-trust

We want to add `sxg_fallback_host` option.