### PR TITLE
Serve SXG only if q-value == 1.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -27,9 +27,11 @@ set (CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -Wall -Wextra -std=c99 -fPIC -g -ggdb")
 set_property (DIRECTORY ${PROJECT_SOURCE_DIR} PROPERTY EP_UPDATE_DISCONNECTED 1)
 
 find_package (OpenSSL REQUIRED)
+find_library (LIBSXG NAMES sxg)
 
 add_library (ngx_sxg_utils SHARED ngx_sxg_utils.c)
-target_link_libraries (ngx_sxg_utils PRIVATE sxg ${OPENSSL_LIBRARIES})
+include_directories(/home/twifkak/usr/include)
+target_link_libraries (ngx_sxg_utils PRIVATE ${LIBSXG} ${OPENSSL_LIBRARIES})
 
 # This target requires cmake-format executable in your path.
 add_custom_target (

--- a/accept_parser_fuzzer.cc
+++ b/accept_parser_fuzzer.cc
@@ -22,6 +22,6 @@
 #include "ngx_sxg_utils.h"
 
 extern "C" int LLVMFuzzerTestOneInput(const uint8_t *data, size_t size) {
-  highest_qvalue_is_sxg(reinterpret_cast<const char *>(data), size);
+  sxg_qvalue_is_1(reinterpret_cast<const char *>(data), size);
   return 0;
 }

--- a/ngx_http_sxg_filter_module.c
+++ b/ngx_http_sxg_filter_module.c
@@ -270,8 +270,8 @@ static bool response_should_be_sxg(const ngx_http_request_t* const req) {
       if (table[i].key.len == strlen(kAccept) &&
           strncasecmp((const char*)table[i].key.data, kAccept,
                       table[i].key.len) == 0 &&
-          highest_qvalue_is_sxg((const char*)table[i].value.data,
-                                table[i].value.len)) {
+          sxg_qvalue_is_1((const char*)table[i].value.data,
+                          table[i].value.len)) {
         return true;
       }
     }

--- a/ngx_sxg_utils.c
+++ b/ngx_sxg_utils.c
@@ -160,21 +160,16 @@ static int get_priority(const char* str, size_t len) {
   return 1000;
 }
 
-bool highest_qvalue_is_sxg(const char* str, size_t len) {
-  int max_priority = 0;
-  bool should_be_sxg = false;
+bool sxg_qvalue_is_1(const char* str, size_t len) {
   for (const char* const end = str + len; str < end;) {
     const size_t tail = get_term_length(str, len, ',', "<>");
-    const bool is_sxg = term_is_sxg(str, tail);
-    const int p = get_priority(str, tail);
-    if (max_priority < p || (max_priority == p && is_sxg)) {
-      should_be_sxg = is_sxg;
-      max_priority = p;
+    if (term_is_sxg(str, tail) && get_priority(str, tail) == 1000) {
+      return true;
     }
     str += tail + 1;
     len -= tail + 1;
   }
-  return should_be_sxg;
+  return false;
 }
 
 // Truncates optional white spaces at head and tail.

--- a/ngx_sxg_utils.h
+++ b/ngx_sxg_utils.h
@@ -47,8 +47,8 @@ size_t get_term_length(const char* str, size_t len, char delimiter,
                        const char quotes[2]);
 
 // Decides response should be SXG or not from HTTP accept header.
-// e.g. application/signed-exchange;q=0.9;v=b3,text/html;q=0.8 -> true
-bool highest_qvalue_is_sxg(const char* param, size_t len);
+// e.g. application/signed-exchange;v=b3,text/html;q=0.8 -> true
+bool sxg_qvalue_is_1(const char* param, size_t len);
 
 // Detects rel="preload" parameter in HTTP link header.
 // e.g. rel="foo preload bar" -> true

--- a/ngx_sxg_utils_test.cc
+++ b/ngx_sxg_utils_test.cc
@@ -34,23 +34,22 @@ TEST(NgxSxgUtilsTest, TermLength) {
 }
 
 bool ShouldBeSXG(const std::string& input) {
-  return highest_qvalue_is_sxg(input.data(), input.size());
+  return sxg_qvalue_is_1(input.data(), input.size());
 }
 
 TEST(NgxSxgUtilsTest, ShouldBeSignedExchange) {
   EXPECT_TRUE(ShouldBeSXG("application/signed-exchange;v=b3"));
-  EXPECT_TRUE(ShouldBeSXG("application/signed-exchange; q=0.8 ; v=b3 "));
-  EXPECT_TRUE(ShouldBeSXG("application/signed-exchange; v=b3 ; q=0.7 "));
+  EXPECT_TRUE(ShouldBeSXG("application/signed-exchange;v=b3,"
+                          "application/signed-exchange;v=b3;q=0.9"));
+  EXPECT_TRUE(ShouldBeSXG("application/signed-exchange;v=b3;q=0.9,"
+                          "application/signed-exchange;v=b3"));
   EXPECT_TRUE(
-      ShouldBeSXG("text/html;q=0.1,application/signed-exchange;Q=0.9;v=b3 "));
-  EXPECT_TRUE(ShouldBeSXG("application/signed-exchange ; q=0.8 ; v=b3 "));
-  EXPECT_TRUE(ShouldBeSXG("application/signed-exchange;Q=0.8;V=\"b3\""));
+      ShouldBeSXG("text/html;q=0.1,application/signed-exchange;Q=1;v=b3 "));
+  EXPECT_TRUE(ShouldBeSXG("application/signed-exchange;V=\"b3\";Q=1"));
   EXPECT_TRUE(
       ShouldBeSXG("application/signed-exchange;v=b3; q=1. ,text/html;q=0.999"));
   EXPECT_TRUE(ShouldBeSXG(
       "application/signed-exchange;v=b3;q=1.000   ,text/html;q=0.999"));
-  EXPECT_TRUE(ShouldBeSXG(
-      "application/signed-exchange;q=0.999; v=b3 ,text/html; q=0.998 "));
   EXPECT_TRUE(ShouldBeSXG("application/signed-exchange;v=b3,text/html"));
   EXPECT_TRUE(ShouldBeSXG("*/*,text/html,application/signed-exchange;v=b3"));
   EXPECT_FALSE(ShouldBeSXG("v=b3"));
@@ -60,8 +59,10 @@ TEST(NgxSxgUtilsTest, ShouldBeSignedExchange) {
       ShouldBeSXG("application/signed-exchange;q=0.99a;v=b3,text/html;q=0.5"));
   EXPECT_FALSE(
       ShouldBeSXG("application/signed-exchange;q=0.8     ;v=b3,text/html;q=1"));
+  EXPECT_FALSE(ShouldBeSXG("application/signed-exchange; v=b3 ; q=0.8 "));
+  EXPECT_FALSE(ShouldBeSXG("application/signed-exchange;V=\"b3\";Q=0.8"));
   EXPECT_FALSE(ShouldBeSXG(
-      "application/signed-exchange;q=0.998;v=b3,text/html;q=0.999"));
+      "application/signed-exchange;v=b3;q=0.999,text/html;q=0.998"));
   EXPECT_FALSE(ShouldBeSXG("text/html"));
   EXPECT_FALSE(ShouldBeSXG("application/signed-exchange;v=b2"));
   EXPECT_FALSE(ShouldBeSXG("application/signed-exchange;v=;;,;;"));

--- a/ngx_sxg_utils_test.cc
+++ b/ngx_sxg_utils_test.cc
@@ -39,10 +39,12 @@ bool ShouldBeSXG(const std::string& input) {
 
 TEST(NgxSxgUtilsTest, ShouldBeSignedExchange) {
   EXPECT_TRUE(ShouldBeSXG("application/signed-exchange;v=b3"));
-  EXPECT_TRUE(ShouldBeSXG("application/signed-exchange;v=b3,"
-                          "application/signed-exchange;v=b3;q=0.9"));
-  EXPECT_TRUE(ShouldBeSXG("application/signed-exchange;v=b3;q=0.9,"
-                          "application/signed-exchange;v=b3"));
+  EXPECT_TRUE(
+      ShouldBeSXG("application/signed-exchange;v=b3,"
+                  "application/signed-exchange;v=b3;q=0.9"));
+  EXPECT_TRUE(
+      ShouldBeSXG("application/signed-exchange;v=b3;q=0.9,"
+                  "application/signed-exchange;v=b3"));
   EXPECT_TRUE(
       ShouldBeSXG("text/html;q=0.1,application/signed-exchange;Q=1;v=b3 "));
   EXPECT_TRUE(ShouldBeSXG("application/signed-exchange;V=\"b3\";Q=1"));


### PR DESCRIPTION
This change from previous behavior is a stopgap until https://crbug.com/1243065
is fixed.

Fixes #102.