### PR TITLE
Fix use-after-free and data race in sxg_cert_path.

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,15 +71,17 @@ Maximum HTTP body size this module can generate SXG from. Default value is
 
 #### sxg\_cert\_path
 
-This directive is optional and experimental. The recommended approach is to use
+This directive is optional. If specified, this should be an absolute path
+corresponding to a file that will be served at the URL specified by
+`sxg_cert_url`. This plugin will then automatically generate and refresh the
+CBOR-encoded certificate file, given the PEM located at `sxg_certificate`. It
+requires that the OCSP responder for the certificate is accessible from your
+nginx server to get OCSP responses.
+
+Alternatively, use
 [`gen-certurl`](https://github.com/WICG/webpackage/blob/main/go/signedexchange/README.md)
 to generate a new `cert-chain+cbor` daily, and serve it statically at the URL
 specified by `sxg_cert_url`.
-
-If specified, this should be an absolute path in which nginx will generate and
-serve the CBOR-encoded certificate file, given the PEM located at
-`sxg_certificate`. It requires that the OCSP responder for the certificate is
-accessible from your nginx server to get OCSP responses.
 
 #### sxg\_expiry\_seconds
 

--- a/ngx_sxg_utils.h
+++ b/ngx_sxg_utils.h
@@ -34,6 +34,8 @@
 extern "C" {
 #endif
 
+// Not thread-safe. Callers are responsible for protecting multithreaded
+// access, including via any of the below functions.
 typedef struct {
   sxg_buffer_t serialized_cert_chain;
   X509* certificate;
@@ -68,14 +70,14 @@ X509* load_x509_cert(const char* filepath);
 // Returns empty ngx_sxg_cert_chain_t.
 ngx_sxg_cert_chain_t ngx_sxg_empty_cert_chain();
 
-// Relase ngx_sxg_empty_cert_chain_t.
+// Release ngx_sxg_empty_cert_chain_t.
 void ngx_sxg_cert_chain_release(ngx_sxg_cert_chain_t* target);
 
 // Loads certificates for Certificate-Chain type.
 bool load_cert_chain(const char* cert_path, ngx_sxg_cert_chain_t* target);
 
 // Loads and serialize Cert-Chain to `dst`.
-bool write_cert_chain(ngx_sxg_cert_chain_t* cert, sxg_buffer_t* dst);
+bool write_cert_chain(const ngx_sxg_cert_chain_t* cert, sxg_buffer_t* dst);
 
 // Checks and refreshes the OCSP response. Returns true if refresh done.
 // Returns false if refresh is not required.


### PR DESCRIPTION
- Add a mutex around access to cert_chain, so that there are no races between
  multiple requests if nginx is build --with-threads.
- Don't call sxg_cert_chain_release, as it releases inner data that is meant to
  persist between requests.
- Don't look at revocation_time from OCSP_single_get0_status; this is only set
  when the status is REVOKED.
- Fix OCSP midpoint computation.

Fixes #104.